### PR TITLE
Fix requrements and rename S3_FOLDER

### DIFF
--- a/bioimageio_uploader_service/api.py
+++ b/bioimageio_uploader_service/api.py
@@ -5,7 +5,11 @@ import traceback
 from typing import Any
 from functools import wraps
 from dataclasses import dataclass, field, InitVar
-from enum import IntEnum, StrEnum, auto
+from enum import IntEnum, auto
+try:
+    from enum import StrEnum
+except ImportError:
+    from strenum import StrEnum
 
 import requests
 from imjoy_rpc.hypha import connect_to_server, login
@@ -18,7 +22,7 @@ from bioimageio_uploader_service import __version__
 class MissingEnvironmentVariable(Exception):
     pass
 
-CONNECTION_VARS = {"host": "S3_HOST", "bucket": "S3_BUCKET", "prefix": "S3_FOLDER"}
+CONNECTION_VARS = {"host": "S3_HOST", "bucket": "S3_BUCKET", "prefix": "S3_PREFIX"}
 if not set(os.environ).issuperset(CONNECTION_VARS.values()):
     logger.error("Must be run with following env vars: {}", ", ".join(CONNECTION_VARS.values()))
     missing = [var for var in CONNECTION_VARS.values() if var not in os.environ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ setuptools==69.0.3
 hypha==0.15.50
 bioimageio-collection-backoffice @ git+https://github.com/bioimage-io/collection@a029bdf
 tomli==2.0.1; python_version < '3.11'
+StrEnum==0.1.0; python_version < '3.11'
 


### PR DESCRIPTION
This PR fixes the requirements for python < 3.11, and rename `S3_FOLDER` to `S3_PREFIX` so we use standard naming.  In addition, `S3_HOST` should actually be called `S3_ENDPOINT`.
